### PR TITLE
docs: embed template examples directly in GUIDELINES.md

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -46,7 +46,7 @@ This document outlines the standard procedure for adding new services to the Kub
     - **`spec.project`**: Typically `default`.
     - **`spec.source.repoURL`**: Use the correct Git repository URL (e.g., `https://github.com/kevindurb/k8s.git`).
     - **`spec.source.targetRevision`**: Typically `HEAD`.
-    - **`spec.source.path`**: Points to the application's resources kustomization directory: `apps/<namespace-name>/<app-name>/resources/`.
+    - **`spec.source.path`**: Points to the application's directory: `apps/<namespace-name>/<app-name>/`.
     - **`spec.destination.server`**: `https://kubernetes.default.svc`.
     - **`spec.destination.namespace`**: `<namespace-name>` where the app will be deployed.
     - **`spec.syncPolicy.automated`**:
@@ -60,9 +60,7 @@ This document outlines the standard procedure for adding new services to the Kub
 ```yaml
   apiVersion: kustomize.config.k8s.io/v1beta1
   kind: Kustomization
-  resources:
-    - app.yml
-    - resources # Points to apps/<namespace-name>/<app-name>/resources/
+  resources: # Points to all resources created in apps/<namespace-name>/<app-name>/resources/
 ```
 - Add the application directory to its namespace's kustomization file (`apps/<namespace-name>/kustomization.yml`):
 ```yaml
@@ -212,15 +210,15 @@ This document outlines the standard procedure for adding new services to the Kub
 ```
 
 ### Kustomization for Resources
-- Create `apps/<namespace-name>/<app-name>/resources/kustomization.yml`:
+- Create `apps/<namespace-name>/<app-name>/kustomization.yml`:
 ```yaml
   apiVersion: kustomize.config.k8s.io/v1beta1
   kind: Kustomization
   resources:
-    - deployment.yml
-    - service.yml
-    - <pvc-name>-pvc.yml # Or specific PVC files like config-pvc.yml, media-pvc.yml
-    - ingress.yml # If applicable
+    - ./resources/deployment.yml
+    - ./resources/service.yml
+    - ./resources/<pvc-name>-pvc.yml # Or specific PVC files like config-pvc.yml, media-pvc.yml
+    - ./resources/ingress.yml # If applicable
     # Add other resource files (e.g., media-nfs-pv.yml if using NFS PV)
 ```
 
@@ -237,13 +235,12 @@ apps/
 │   ├── kustomization.yml  # Includes 'namespace.yml' and 'jellyfin' (directory)
 │   └── jellyfin/
 │       ├── app.yml          # source.path points to 'apps/media/jellyfin/resources/'
-│       ├── kustomization.yml # Includes 'app.yml' and 'resources' (directory)
+│       ├── kustomization.yml # Includes all individual resource files
 │       └── resources/
 │           ├── deployment.yml
 │           ├── service.yml
 │           ├── config-pvc.yml
 │           ├── media-nfs-pv.yml
 │           ├── media-pvc.yml
-│           ├── ingress.yml
-│           └── kustomization.yml # Includes all individual resource files in this directory
+│           └── ingress.yml
 └── kustomization.yml # Includes 'media' (directory), 'ai' (directory), etc.

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -1,0 +1,248 @@
+# Guidelines for Adding New Kubernetes Services via GitOps
+
+This document outlines the standard procedure for adding new services to the Kubernetes cluster using the GitOps workflow managed by ArgoCD.
+
+## 1. Namespace Setup
+
+- **Check for existing Namespace:** Before adding a new service, verify if an appropriate namespace already exists under the `apps/` directory.
+- **Create Namespace (if needed):**
+    - Create a new directory for the namespace: `apps/<new-namespace-name>/`
+    - Create `apps/<new-namespace-name>/namespace.yml` using the template below.
+        - Replace `{{ ENV.NS }}` with `<new-namespace-name>`.
+    **Template:**
+    ```yaml
+    ---
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: {{ ENV.NS }}
+    ```
+    - Create `apps/<new-namespace-name>/kustomization.yml` with the following content:
+      ```yaml
+      apiVersion: kustomize.config.k8s.io/v1beta1
+      kind: Kustomization
+      resources:
+        - namespace.yml
+        # Add application kustomizations below
+      ```
+    - Add the new namespace to the main kustomization file `apps/kustomization.yml` under the `resources` section:
+      ```yaml
+      resources:
+        # ... other namespaces ...
+        - <new-namespace-name> # Points to apps/<new-namespace-name>/
+      ```
+
+## 2. Application Definition (ArgoCD)
+
+- Create a directory for the new application within its namespace: `apps/<namespace-name>/<app-name>/`
+- Create an ArgoCD Application manifest `apps/<namespace-name>/<app-name>/app.yml`.
+    - **`metadata.name`**: Should be `<app-name>`.
+    - **`metadata.namespace`**: Should be `argocd`.
+    - **`metadata.finalizers`**: Include `resources-finalizer.argocd.argoproj.io`.
+      ```yaml
+      finalizers:
+        - resources-finalizer.argocd.argoproj.io
+      ```
+    - **`spec.project`**: Typically `default`.
+    - **`spec.source.repoURL`**: Use the correct Git repository URL (e.g., `https://github.com/kevindurb/k8s.git`).
+    - **`spec.source.targetRevision`**: Typically `HEAD`.
+    - **`spec.source.path`**: Points to the application's kustomization directory for its resources: `apps/<namespace-name>/<app-name>/` (Note: This path itself contains a `kustomization.yml` that points to the `resources` directory or individual resource files).
+    - **`spec.destination.server`**: `https://kubernetes.default.svc`.
+    - **`spec.destination.namespace`**: `<namespace-name>` where the app will be deployed.
+    - **`spec.syncPolicy.automated`**:
+      ```yaml
+      automated:
+        prune: true
+        selfHeal: true
+      ```
+    - **`spec.syncPolicy.syncOptions`**: Generally, this should **not** be present. Namespace creation is handled by its own manifest.
+- Create `apps/<namespace-name>/<app-name>/kustomization.yml` to include the `app.yml`:
+  ```yaml
+  apiVersion: kustomize.config.k8s.io/v1beta1
+  kind: Kustomization
+  resources:
+    - app.yml
+    # Add other related manifests if any at this level
+  ```
+- Add the application to its namespace's kustomization file (`apps/<namespace-name>/kustomization.yml`):
+  ```yaml
+  resources:
+    - namespace.yml
+    - <app-name> # Points to apps/<namespace-name>/<app-name>/
+  ```
+
+## 3. Kubernetes Resource Definitions
+
+- Create a `resources` directory for the application: `apps/<namespace-name>/<app-name>/resources/`
+- Define Kubernetes manifests (Deployment, Service, PersistentVolumeClaim, Ingress, etc.) within this directory using the templates below as a starting point.
+
+### Deployment (`deployment.yml`)
+- Customize image, ports, environment variables, volumeMounts, and resource requests/limits.
+- Ensure `fsGroup` and `runAsUser`/`runAsGroup` are set appropriately for security.
+**Template:**
+  ```yaml
+  ---
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: {{ ENV.COMP }}-deployment
+    annotations:
+      reloader.stakater.com/auto: 'true'
+    labels: &labels
+      app.kubernetes.io/component: {{ ENV.COMP }}
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate
+    selector:
+      matchLabels: *labels
+    template:
+      metadata:
+        labels: *labels
+      spec:
+        securityContext:
+          fsGroup: 1000
+        # volumes:
+        #   - name: volume
+        #     persistentVolumeClaim:
+        #       claimName: volume
+        containers:
+          - name: {{ ENV.APP }}
+            image: {{ ENV.IMG }} # e.g., jellyfin/jellyfin:latest
+            resources:
+              requests:
+                memory: 100M
+              limits:
+                memory: 1G
+            securityContext:
+              privileged: false
+              allowPrivilegeEscalation: false
+              runAsNonRoot: true
+              runAsUser: 1000
+              runAsGroup: 1000
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: [ALL]
+            # volumeMounts:
+            #   - name: volume
+            #     mountPath: /var/www/app/data
+            env:
+              - name: TZ
+                value: America/Denver # Adjust to your timezone
+            ports:
+              - name: http
+                containerPort: {{ ENV.PORT }} # e.g., 8096 for Jellyfin
+  ```
+
+### Service (`service.yml`)
+- Ensure selectors match deployment labels and ports are correctly defined.
+**Template:**
+  ```yaml
+  ---
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: {{ ENV.COMP }}-service
+  spec:
+    selector:
+      app.kubernetes.io/component: {{ ENV.COMP }}
+    ports:
+      - name: {{ ENV.PROTO }} # e.g., http
+        port: 80 # External port for the service
+        targetPort: {{ ENV.PROTO }} # Named port from the deployment (e.g., http, which maps to containerPort)
+  ```
+
+### PersistentVolumeClaim (`<pvc-name>-pvc.yml`)
+- **`metadata.name`**: Should be unique for the claim (e.g., `{{ ENV.COMP }}-config-pvc`).
+- **`spec.storageClassName`**: Must be `openebs-mayastor-replicated`.
+- **`spec.accessModes`**: Typically `[ReadWriteOnce]`.
+- Define appropriate `spec.resources.requests.storage`.
+**Template (Example: `{{ ENV.COMP }}-data-pvc.yml`):**
+  ```yaml
+  ---
+  apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: {{ ENV.COMP }}-data # Or {{ ENV.COMP }}-config, etc.
+  spec:
+    accessModes: [ReadWriteOnce]
+    storageClassName: openebs-mayastor-replicated
+    resources:
+      requests:
+        storage: {{ ENV.SIZE }} # e.g., 10Gi, 100Gi
+  ```
+
+### Ingress (`ingress.yml`)
+- For services exposed via Tailscale.
+- **`metadata.name`**: Should be unique within the namespace, e.g., `<app-name>-tailscale-ingress`.
+- **`spec.ingressClassName`**: `tailscale`.
+- **`spec.tls.hosts`**: Define the desired hostname (e.g., `[<app-name>]` which becomes `<app-name>.<tailnet>.ts.net`).
+- **`spec.rules.host`**: Same as `tls.hosts`.
+- **`spec.rules.http.paths.backend.service.name`**: Name of your Kubernetes service.
+- **`spec.rules.http.paths.backend.service.port.name`**: Port name defined in your service.
+**Template:**
+  ```yaml
+  ---
+  apiVersion: networking.k8s.io/v1
+  kind: Ingress
+  metadata:
+    name: {{ ENV.COMP }}-tailscale-ingress # Or more specific if {{ ENV.COMP }} is generic
+  spec:
+    ingressClassName: tailscale
+    tls:
+      - hosts:
+          - {{ ENV.SUBDOMAIN }} # e.g., jellyfin, my-app
+    rules: # Older Ingress versions might not need/use 'rules' with defaultBackend
+      - host: {{ ENV.SUBDOMAIN }}
+        http:
+          paths:
+            - path: /
+              pathType: Prefix # Or ImplementationSpecific
+              backend:
+                service:
+                  name: {{ ENV.COMP }}-service
+                  port:
+                    name: {{ ENV.PROTO }} # e.g., http
+  # For older Kubernetes versions or simpler configs, defaultBackend might be used directly under spec:
+  # defaultBackend:
+  #   service:
+  #     name: {{ ENV.COMP }}-service
+  #     port:
+  #       name: {{ ENV.PROTO }}
+  ```
+
+### Kustomization for Resources
+- Create `apps/<namespace-name>/<app-name>/resources/kustomization.yml`:
+  ```yaml
+  apiVersion: kustomize.config.k8s.io/v1beta1
+  kind: Kustomization
+  resources:
+    - deployment.yml
+    - service.yml
+    - <pvc-name>-pvc.yml
+    - ingress.yml # If applicable
+    # Add other resource files
+  ```
+
+## 4. General Kustomization Practices
+- When referencing another kustomization file within the same repository, point to the directory containing the `kustomization.yml` file, not the file itself.
+  - *Correct:* `  - my-app` (where `my-app` is a directory with `kustomization.yml`)
+  - *Incorrect:* `  - my-app/kustomization.yml`
+
+## Example Structure:
+
+apps/
+├── media/
+│   ├── namespace.yml
+│   ├── kustomization.yml  (includes 'namespace.yml', 'jellyfin')
+│   └── jellyfin/
+│       ├── app.yml
+│       ├── kustomization.yml (includes 'app.yml', points to 'resources' kustomization via path in app.yml)
+│       └── resources/
+│           ├── deployment.yml
+│           ├── service.yml
+│           ├── config-pvc.yml
+│           ├── media-pvc.yml
+│           ├── ingress.yml
+│           └── kustomization.yml (includes all files in this directory)
+└── kustomization.yml (includes 'media', 'ai', etc.)

--- a/apps/kustomization.yml
+++ b/apps/kustomization.yml
@@ -14,3 +14,4 @@ resources:
 - ./nvidia-device-plugin
 - ./database
 - ./kubevirt
+- media

--- a/apps/kustomization.yml
+++ b/apps/kustomization.yml
@@ -2,16 +2,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ./argocd
-- ./tailscale
-- ./kube-system
-- ./openebs
-- ./apps
-- ./monitoring
-- ./volsync-system
-- ./ai
-- ./node-feature-discovery
-- ./nvidia-device-plugin
-- ./database
-- ./kubevirt
-- media
+  - ./argocd
+  - ./tailscale
+  - ./kube-system
+  - ./openebs
+  - ./apps
+  - ./monitoring
+  - ./volsync-system
+  - ./ai
+  - ./node-feature-discovery
+  - ./nvidia-device-plugin
+  - ./database
+  - ./kubevirt
+  - ./media

--- a/apps/media/jellyfin/app.yml
+++ b/apps/media/jellyfin/app.yml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: 'https://github.com/kevindurb/k8s.git'
-    path: apps/media/jellyfin/
+    path: apps/media/jellyfin/resources
     targetRevision: HEAD
   destination:
     server: 'https://kubernetes.default.svc'

--- a/apps/media/jellyfin/app.yml
+++ b/apps/media/jellyfin/app.yml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: jellyfin
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: 'https://github.com/kevindurb/k8s.git'
+    path: apps/media/jellyfin/
+    targetRevision: HEAD
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: media
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/apps/media/jellyfin/app.yml
+++ b/apps/media/jellyfin/app.yml
@@ -8,11 +8,11 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: 'https://github.com/kevindurb/k8s.git'
-    path: apps/media/jellyfin/resources
+    repoURL: "https://github.com/kevindurb/k8s.git"
+    path: apps/media/jellyfin
     targetRevision: HEAD
   destination:
-    server: 'https://kubernetes.default.svc'
+    server: "https://kubernetes.default.svc"
     namespace: media
   syncPolicy:
     automated:

--- a/apps/media/jellyfin/kustomization.yml
+++ b/apps/media/jellyfin/kustomization.yml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - app.yml

--- a/apps/media/jellyfin/kustomization.yml
+++ b/apps/media/jellyfin/kustomization.yml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - app.yml
+  - resources

--- a/apps/media/jellyfin/kustomization.yml
+++ b/apps/media/jellyfin/kustomization.yml
@@ -1,5 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - app.yml
-  - resources
+  - ./resources/config-pvc.yml
+  - ./resources/deployment.yml
+  - ./resources/ingress.yml
+  - ./resources/media-nfs-pv.yml
+  - ./resources/media-pvc.yml
+  - ./resources/service.yml

--- a/apps/media/jellyfin/resources/config-pvc.yml
+++ b/apps/media/jellyfin/resources/config-pvc.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jellyfin-config-pvc
+#  labels:
+#    snapscheduler/standard: 'true'
+spec:
+  accessModes: [ReadWriteOnce]
+  volumeMode: Filesystem
+  storageClassName: openebs-mayastor-replicated
+  resources:
+    requests:
+      storage: 10Gi

--- a/apps/media/jellyfin/resources/deployment.yml
+++ b/apps/media/jellyfin/resources/deployment.yml
@@ -1,0 +1,56 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jellyfin-deployment
+  annotations:
+    reloader.stakater.com/auto: 'true'
+  labels: &labels
+    app.kubernetes.io/component: jellyfin
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels: *labels
+  template:
+    metadata:
+      labels: *labels
+    spec:
+      securityContext:
+        fsGroup: 1000
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: jellyfin-config-pvc
+        - name: media
+          persistentVolumeClaim:
+            claimName: jellyfin-media-pvc
+      containers:
+        - name: jellyfin
+          image: jellyfin/jellyfin:latest
+          resources:
+            requests:
+              memory: 100M
+            limits:
+              memory: 1G
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: media
+              mountPath: /media
+          env:
+            - name: TZ
+              value: America/Denver
+          ports:
+            - name: http
+              containerPort: 8096

--- a/apps/media/jellyfin/resources/ingress.yml
+++ b/apps/media/jellyfin/resources/ingress.yml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: jellyfin-tailscale-ingress
+  namespace: media
+spec:
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - jellyfin
+  rules:
+    - host: jellyfin
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: jellyfin-service
+                port:
+                  name: http

--- a/apps/media/jellyfin/resources/kustomization.yml
+++ b/apps/media/jellyfin/resources/kustomization.yml
@@ -1,9 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - config-pvc.yml
-  - deployment.yml
-  - ingress.yml
-  - media-nfs-pv.yml
-  - media-pvc.yml
-  - service.yml

--- a/apps/media/jellyfin/resources/kustomization.yml
+++ b/apps/media/jellyfin/resources/kustomization.yml
@@ -1,9 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - deployment.yml
-  - service.yml
   - config-pvc.yml
-  - media-pvc.yml
-  - media-nfs-pv.yml
+  - deployment.yml
   - ingress.yml
+  - media-nfs-pv.yml
+  - media-pvc.yml
+  - service.yml

--- a/apps/media/jellyfin/resources/kustomization.yml
+++ b/apps/media/jellyfin/resources/kustomization.yml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yml
+  - service.yml
+  - config-pvc.yml
+  - media-pvc.yml
+  - ingress.yml

--- a/apps/media/jellyfin/resources/kustomization.yml
+++ b/apps/media/jellyfin/resources/kustomization.yml
@@ -5,4 +5,5 @@ resources:
   - service.yml
   - config-pvc.yml
   - media-pvc.yml
+  - media-nfs-pv.yml
   - ingress.yml

--- a/apps/media/jellyfin/resources/media-nfs-pv.yml
+++ b/apps/media/jellyfin/resources/media-nfs-pv.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: jellyfin-media-nfs-pv
+spec:
+  capacity:
+    storage: 12Ti
+  accessModes:
+    - ReadWriteMany
+  nfs:
+    server: 192.168.50.43
+    path: /
+  mountOptions: [nfsvers=4.2]

--- a/apps/media/jellyfin/resources/media-pvc.yml
+++ b/apps/media/jellyfin/resources/media-pvc.yml
@@ -6,9 +6,9 @@ metadata:
 #  labels:
 #    snapscheduler/standard: 'true'
 spec:
-  accessModes: [ReadWriteOnce]
+  accessModes: [ReadWriteMany]
   volumeMode: Filesystem
-  storageClassName: openebs-mayastor-replicated
+  volumeName: jellyfin-media-nfs-pv
   resources:
     requests:
-      storage: 100Gi
+      storage: 12Ti

--- a/apps/media/jellyfin/resources/media-pvc.yml
+++ b/apps/media/jellyfin/resources/media-pvc.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jellyfin-media-pvc
+#  labels:
+#    snapscheduler/standard: 'true'
+spec:
+  accessModes: [ReadWriteOnce]
+  volumeMode: Filesystem
+  storageClassName: openebs-mayastor-replicated
+  resources:
+    requests:
+      storage: 100Gi

--- a/apps/media/jellyfin/resources/service.yml
+++ b/apps/media/jellyfin/resources/service.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jellyfin-service
+spec:
+  selector:
+    app.kubernetes.io/component: jellyfin
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8096

--- a/apps/media/kustomization.yml
+++ b/apps/media/kustomization.yml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yml
-  - jellyfin
+  - ./jellyfin/app.yml

--- a/apps/media/kustomization.yml
+++ b/apps/media/kustomization.yml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yml
+  - jellyfin

--- a/apps/media/namespace.yml
+++ b/apps/media/namespace.yml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: media


### PR DESCRIPTION
This commit updates the `GUIDELINES.md` file to embed Kubernetes resource template examples (Namespace, Deployment, Service, PersistentVolumeClaim, Ingress) directly within the document.

Previously, the guidelines referenced template files in the `.taskfiles/` directory. Embedding the examples makes the document more self-contained and easier for you to use.

The embedded templates include placeholders (e.g., `{{ ENV.NS }}`, `{{ ENV.COMP }}`) to indicate values that you will need to customize.