### PR TITLE
Use nas-media component for sonarr's NFS PV+PVC

### DIFF
--- a/apps/sonarr/deployment.yml
+++ b/apps/sonarr/deployment.yml
@@ -45,33 +45,6 @@ spec:
               containerPort: 8989
 ---
 apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: nas-media
-spec:
-  capacity:
-    storage: 12Ti
-  accessModes:
-    - ReadWriteMany
-  nfs:
-    server: 192.168.42.24
-    path: /
-  mountOptions: [nfsvers=4.2]
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: nas-media
-spec:
-  accessModes:
-    - ReadWriteMany
-  storageClassName: ''
-  volumeName: nas-media
-  resources:
-    requests:
-      storage: 12Ti
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: volume

--- a/apps/sonarr/kustomization.yml
+++ b/apps/sonarr/kustomization.yml
@@ -10,6 +10,7 @@ resources:
 
 components:
   - ../../components/http-route-refs
+  - ../../components/nas-media
   - ../../components/app-pod-hardening
   - ../../components/app-tmp-dirs
 


### PR DESCRIPTION
## Summary

Sonarr (merged via #439) inlined the NFS PV+PVC into `deployment.yml`. That config is the same across every NAS-using app, so this PR pulls it back into the shared `nas-media` component, leaving only the per-deployment volume + volumeMount choices in `deployment.yml`.

The component's labelSelector-gated patch is a no-op now that the `beaver-cloud.xyz/nas-media` label is gone.

#440 (radarr) does the same thing — that PR includes this change in its 2nd commit so radarr never lands on main in the inline state.

## Test plan

- [x] `kubectl kustomize apps/sonarr` — byte-identical to current main
- [x] `just test/test apps/sonarr` — snapshot unchanged
- [x] Pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)