### PR TITLE
Refactor scrypted: drop components, switch to app-* convention

### DIFF
--- a/apps/scrypted/deployment.yml
+++ b/apps/scrypted/deployment.yml
@@ -2,9 +2,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: web-deployment
+  name: app-deployment
   labels: &labels
-    app.kubernetes.io/component: web
+    app.kubernetes.io/component: app
 spec:
   replicas: 1
   strategy:
@@ -15,6 +15,8 @@ spec:
     metadata:
       labels: *labels
     spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       runtimeClassName: nvidia
       nodeSelector:
         nvidia.com/gpu.product: Quadro-P620-SHARED
@@ -25,22 +27,21 @@ spec:
       containers:
         - name: scrypted
           image: ghcr.io/koush/scrypted:v0.144.1-noble-nvidia@sha256:da86752279289444ba093caf908c2534abbdf134058143755cd0b085bd88b47c
+          env:
+            - name: TZ
+              value: America/Denver
+          volumeMounts:
+            - name: volume
+              mountPath: /server/volume
           resources:
             requests:
               memory: 100M
             limits:
-              nvidia.com/gpu: '1'
               memory: 4G
-          volumeMounts:
-            - name: volume
-              mountPath: /server/volume
-          env:
-            - name: TZ
-              value: America/Denver
+              nvidia.com/gpu: '1'
           ports:
             - name: http
               containerPort: 11080
-
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -52,7 +53,6 @@ spec:
   resources:
     requests:
       storage: 10G
-
 ---
 apiVersion: v1
 kind: Service
@@ -60,8 +60,34 @@ metadata:
   name: app-service
 spec:
   selector:
-    app.kubernetes.io/component: web
+    app.kubernetes.io/component: app
   ports:
     - name: http
       port: 80
       targetPort: http
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: internal-route
+  annotations:
+    internal-dns.alpha.kubernetes.io/target: internal.beaver-cloud.xyz
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: internal-beaver-cloud
+      namespace: envoy-gateway-system
+  hostnames:
+    - scrypted.beaver-cloud.xyz
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ''
+          kind: Service
+          name: app-service
+          port: 80
+          weight: 1

--- a/apps/scrypted/kustomization.yml
+++ b/apps/scrypted/kustomization.yml
@@ -6,27 +6,18 @@ namespace: scrypted
 namePrefix: scrypted-
 
 resources:
-  - ./scrypted.yml
+  - ./deployment.yml
 
 components:
-  - ../../components/host-networking
-  - ../../components/internal-http-route
-
-replacements:
-  - sourceValue: scrypted.beaver-cloud.xyz
-    targets:
-      - select:
-          kind: HTTPRoute
-        fieldPaths:
-          - spec.hostnames.0
+  - ../../components/http-route-refs
 
 configMapGenerator:
-  - files:
-      - scrypted.yml=gatus.yml
-    name: gatus
+  - name: gatus
     options:
       labels:
         gatus.io/enabled: 'true'
+    files:
+      - scrypted.yml=gatus.yml
 
 labels:
   - includeSelectors: true

--- a/test/snapshots/apps/scrypted/out.yml
+++ b/test/snapshots/apps/scrypted/out.yml
@@ -29,7 +29,7 @@ spec:
     port: 80
     targetPort: http
   selector:
-    app.kubernetes.io/component: web
+    app.kubernetes.io/component: app
     app.kubernetes.io/name: scrypted
 ---
 apiVersion: v1
@@ -51,22 +51,22 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: web
+    app.kubernetes.io/component: app
     app.kubernetes.io/name: scrypted
-  name: scrypted-web-deployment
+  name: scrypted-app-deployment
   namespace: scrypted
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: web
+      app.kubernetes.io/component: app
       app.kubernetes.io/name: scrypted
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: web
+        app.kubernetes.io/component: app
         app.kubernetes.io/name: scrypted
     spec:
       containers:


### PR DESCRIPTION
## Summary

Same shape as #439/#440 but tailored to scrypted's quirks:

- Inline `hostNetwork: true` + `dnsPolicy: ClusterFirstWithHostNet` (was the `host-networking` component)
- Inline config PVC, Service, HTTPRoute into `apps/scrypted/deployment.yml` (renamed from `scrypted.yml`)
- Hard-code `scrypted.beaver-cloud.xyz`
- Drop `host-networking` and `internal-http-route` components
- Add `http-route-refs`
- Rename `web-deployment` → `app-deployment`, component label `web` → `app`

Pod-hardening and tmpdirs intentionally not added — scrypted needs broad permissions (nvidia GPU, host network, camera discovery) and was already running without them.

### Cutover

`Deployment.spec.selector` mutation forces ArgoCD to create `scrypted-app-deployment`, then prune `scrypted-web-deployment` (PVC RWO contention briefly gates the new pod). Expect ~30-60s of unavailability. No data loss.

## Test plan

- [x] `kubectl kustomize apps/scrypted` — renders the expected label+name diff
- [x] `just test/test apps/scrypted` — snapshot updated
- [x] Pre-commit clean
- [ ] Post-merge: `argocd app get scrypted` → Synced + Healthy, GPU + host network still functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)