### PR TITLE
Refactor syncthing: drop components, switch to app-* convention

### DIFF
--- a/apps/syncthing/deployment.yml
+++ b/apps/syncthing/deployment.yml
@@ -2,9 +2,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: web-deployment
+  name: app-deployment
   labels: &labels
-    app.kubernetes.io/component: web
+    app.kubernetes.io/component: app
 spec:
   replicas: 1
   strategy:
@@ -15,6 +15,8 @@ spec:
     metadata:
       labels: *labels
     spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       volumes:
         - name: volume
           persistentVolumeClaim:
@@ -22,14 +24,6 @@ spec:
       containers:
         - name: syncthing
           image: docker.io/syncthing/syncthing:2.0.16@sha256:4a961394ca471f4e48f31ad2cef50697e502c8799e2e98477a1c3844e0c5bc54
-          resources:
-            requests:
-              memory: 100M
-            limits:
-              memory: 4G
-          volumeMounts:
-            - name: volume
-              mountPath: /var/syncthing
           env:
             - name: TZ
               value: America/Denver
@@ -37,10 +31,17 @@ spec:
               value: '1000'
             - name: PGID
               value: '1000'
+          volumeMounts:
+            - name: volume
+              mountPath: /var/syncthing
+          resources:
+            requests:
+              memory: 100M
+            limits:
+              memory: 4G
           ports:
             - name: http
               containerPort: 8384
-
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -52,7 +53,6 @@ spec:
   resources:
     requests:
       storage: 100G
-
 ---
 apiVersion: v1
 kind: Service
@@ -60,8 +60,34 @@ metadata:
   name: app-service
 spec:
   selector:
-    app.kubernetes.io/component: web
+    app.kubernetes.io/component: app
   ports:
     - name: http
       port: 80
       targetPort: http
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: internal-route
+  annotations:
+    internal-dns.alpha.kubernetes.io/target: internal.beaver-cloud.xyz
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: internal-beaver-cloud
+      namespace: envoy-gateway-system
+  hostnames:
+    - syncthing.beaver-cloud.xyz
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ''
+          kind: Service
+          name: app-service
+          port: 80
+          weight: 1

--- a/apps/syncthing/kustomization.yml
+++ b/apps/syncthing/kustomization.yml
@@ -6,21 +6,12 @@ namespace: syncthing
 namePrefix: syncthing-
 
 resources:
-  - ./syncthing.yml
+  - ./deployment.yml
 
 components:
-  - ../../components/pod-hardening
-  - ../../components/tmpdirs
-  - ../../components/host-networking
-  - ../../components/internal-http-route
-
-replacements:
-  - sourceValue: syncthing.beaver-cloud.xyz
-    targets:
-      - select:
-          kind: HTTPRoute
-        fieldPaths:
-          - spec.hostnames.0
+  - ../../components/http-route-refs
+  - ../../components/app-pod-hardening
+  - ../../components/app-tmp-dirs
 
 configMapGenerator:
   - name: gatus

--- a/test/snapshots/apps/syncthing/out.yml
+++ b/test/snapshots/apps/syncthing/out.yml
@@ -29,7 +29,7 @@ spec:
     port: 80
     targetPort: http
   selector:
-    app.kubernetes.io/component: web
+    app.kubernetes.io/component: app
     app.kubernetes.io/name: syncthing
 ---
 apiVersion: v1
@@ -51,22 +51,22 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: web
+    app.kubernetes.io/component: app
     app.kubernetes.io/name: syncthing
-  name: syncthing-web-deployment
+  name: syncthing-app-deployment
   namespace: syncthing
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: web
+      app.kubernetes.io/component: app
       app.kubernetes.io/name: syncthing
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: web
+        app.kubernetes.io/component: app
         app.kubernetes.io/name: syncthing
     spec:
       containers:


### PR DESCRIPTION
Same pattern as #439/#440/#442:
- Inline hostNetwork+dnsPolicy, PVC, Service, HTTPRoute into `deployment.yml` (renamed from `syncthing.yml`)
- Hard-code hostname; drop replacement
- Drop `pod-hardening`, `tmpdirs`, `host-networking`, `internal-http-route` components
- Add `http-route-refs`, `app-pod-hardening`, `app-tmp-dirs`
- Rename Deployment + flip component label to match app-* convention

Cutover: Deployment.spec.selector mutation forces ArgoCD to recreate. PVC RWO gates the new pod briefly. ~30-60s of syncthing downtime.

- [x] kustomize build matches expected diff
- [x] snapshot updated
- [x] pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)