### PR TITLE
Refactor forgejo: drop bases and components, inline everything

### DIFF
--- a/apps/forgejo/deployment.yml
+++ b/apps/forgejo/deployment.yml
@@ -1,0 +1,93 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-deployment
+  labels: &labels
+    app.kubernetes.io/component: app
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels: *labels
+  template:
+    metadata:
+      labels: *labels
+    spec:
+      volumes:
+        - name: volume
+          persistentVolumeClaim:
+            claimName: app-volume
+      containers:
+        - name: app
+          image: codeberg.org/forgejo/forgejo:15-rootless
+          env:
+            - name: TZ
+              value: America/Denver
+          envFrom:
+            - configMapRef:
+                name: app-env
+          volumeMounts:
+            - name: volume
+              mountPath: /var/lib/gitea
+          resources:
+            requests:
+              memory: 100M
+            limits:
+              memory: 1G
+          ports:
+            - name: http
+              containerPort: 3000
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: app-volume
+  labels:
+    app.kubernetes.io/component: app
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: longhorn-replicated
+  resources:
+    requests:
+      storage: 10G
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app-service
+  labels: &labels
+    app.kubernetes.io/component: app
+spec:
+  selector: *labels
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: internal-route
+  annotations:
+    internal-dns.alpha.kubernetes.io/target: internal.beaver-cloud.xyz
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: internal-beaver-cloud
+      namespace: envoy-gateway-system
+  hostnames:
+    - forgejo.beaver-cloud.xyz
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ''
+          kind: Service
+          name: app-service
+          port: 80
+          weight: 1

--- a/apps/forgejo/kustomization.yml
+++ b/apps/forgejo/kustomization.yml
@@ -6,16 +6,12 @@ namespace: forgejo
 namePrefix: forgejo-
 
 resources:
-  - ../../bases/app-with-storage
+  - ./deployment.yml
 
 components:
-  - ../../components/internal-http-route
-  - ../../components/app-env
-
-images:
-  - name: app-image
-    newName: codeberg.org/forgejo/forgejo
-    newTag: 15-rootless
+  - ../../components/http-route-refs
+  - ../../components/app-pod-hardening
+  - ../../components/app-tmp-dirs
 
 configMapGenerator:
   - name: gatus
@@ -28,33 +24,6 @@ configMapGenerator:
     literals:
       - USER_UID=1000
       - USER_GID=1000
-
-replacements:
-  - sourceValue: '3000'
-    targets:
-      - select: &app-deployment
-          kind: Deployment
-          name: app-deployment
-        fieldPaths:
-          - spec.template.spec.containers.[name=app].ports.[name=http].containerPort
-  - sourceValue: forgejo.beaver-cloud.xyz
-    targets:
-      - select:
-          kind: HTTPRoute
-        fieldPaths:
-          - spec.hostnames.0
-  - sourceValue: 10G
-    targets:
-      - select:
-          kind: PersistentVolumeClaim
-          name: app-volume
-        fieldPaths:
-          - spec.resources.requests.storage
-  - sourceValue: /var/lib/gitea
-    targets:
-      - select: *app-deployment
-        fieldPaths:
-          - spec.template.spec.containers.0.volumeMounts.[name=volume].mountPath
 
 labels:
   - includeSelectors: true

--- a/test/snapshots/apps/forgejo/out.yml
+++ b/test/snapshots/apps/forgejo/out.yml
@@ -48,6 +48,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   labels:
+    app.kubernetes.io/component: app
     app.kubernetes.io/name: forgejo
   name: forgejo-app-volume
   namespace: forgejo


### PR DESCRIPTION
- Drop \`bases/app-with-storage\` and \`internal-http-route\`/\`app-env\` components
- Drop the four replacements (port, hostname, storage size, mountPath) and the \`&app-deployment\` anchor — all literal values in the inline Deployment now
- Drop the \`images:\` mapping
- Inline Deployment + PVC + Service + HTTPRoute in \`deployment.yml\`
- Add \`http-route-refs\`, \`app-pod-hardening\`, \`app-tmp-dirs\`
- Keep configMapGenerator for gatus + \`app-env\` literals

## No cutover

Unlike sonarr/radarr/syncthing/etc., forgejo already rendered with \`component: app\` and Deployment name \`app-deployment\` (via bases/app). No selector mutation, no recreation — ArgoCD apply should be in-place. Only diff is one added label on the PVC (\`app.kubernetes.io/component: app\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)