### PR TITLE
Refactor makemkv: drop bases and components, inline everything

### DIFF
--- a/apps/makemkv/deployment.yml
+++ b/apps/makemkv/deployment.yml
@@ -1,0 +1,87 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-deployment
+  labels: &labels
+    app.kubernetes.io/component: app
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels: *labels
+  template:
+    metadata:
+      labels: *labels
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: drone-04
+      securityContext:
+        fsGroup: 1000
+      volumes:
+        - name: nas-media
+          persistentVolumeClaim:
+            claimName: nas-media
+      containers:
+        - name: app
+          image: jlesage/makemkv:v26.01.2@sha256:4c114cfbd0ba7feef85c72d1721b8ea13a44ebc010b4996b644e618906e61717
+          securityContext:
+            privileged: true
+          env:
+            - name: TZ
+              value: America/Denver
+          envFrom:
+            - configMapRef:
+                name: app-env
+          volumeMounts:
+            - name: nas-media
+              mountPath: /output
+              subPath: Downloads
+          resources:
+            requests:
+              memory: 100M
+            limits:
+              memory: 1G
+          ports:
+            - name: http
+              containerPort: 5800
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app-service
+  labels: &labels
+    app.kubernetes.io/component: app
+spec:
+  selector: *labels
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: internal-route
+  annotations:
+    internal-dns.alpha.kubernetes.io/target: internal.beaver-cloud.xyz
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: internal-beaver-cloud
+      namespace: envoy-gateway-system
+  hostnames:
+    - makemkv.beaver-cloud.xyz
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ''
+          kind: Service
+          name: app-service
+          port: 80
+          weight: 1

--- a/apps/makemkv/kustomization.yml
+++ b/apps/makemkv/kustomization.yml
@@ -6,18 +6,12 @@ namespace: makemkv
 namePrefix: makemkv-
 
 resources:
-  - ../../bases/app
+  - ./deployment.yml
 
 components:
-  - ../../components/app-nas-media
-  - ../../components/internal-http-route
-  - ../../components/app-env
-  - ../../components/privileged-app
-
-images:
-  - name: app-image
-    newName: jlesage/makemkv
-    newTag: v26.01.2@sha256:4c114cfbd0ba7feef85c72d1721b8ea13a44ebc010b4996b644e618906e61717
+  - ../../components/http-route-refs
+  - ../../components/nas-media
+  - ../../components/app-tmp-dirs
 
 configMapGenerator:
   - name: gatus
@@ -38,36 +32,6 @@ configMapGenerator:
       - AUTO_DISC_RIPPER_EJECT=1
       - AUTO_DISC_RIPPER_MIN_TITLE_LENGTH=600 # 10 minutes
       - AUTO_DISC_RIPPER_FORCE_UNIQUE_OUTPUT_DIR=1
-
-replacements:
-  - sourceValue: '5800'
-    targets:
-      - select: &app-deployment
-          kind: Deployment
-          name: app-deployment
-        fieldPaths:
-          - spec.template.spec.containers.[name=app].ports.[name=http].containerPort
-
-  - sourceValue: makemkv.beaver-cloud.xyz
-    targets:
-      - select:
-          kind: HTTPRoute
-        fieldPaths:
-          - spec.hostnames.0
-
-patches:
-  - patch: |-
-      - op: add
-        path: /spec/template/spec/nodeSelector
-        value:
-          kubernetes.io/hostname: drone-04
-      - op: replace
-        path: /spec/template/spec/containers/0/volumeMounts/0
-        value:
-          name: nas-media
-          mountPath: /output
-          subPath: Downloads
-    target: *app-deployment
 
 labels:
   - includeSelectors: true


### PR DESCRIPTION
- Drop \`bases/app\`, \`app-nas-media\`, \`internal-http-route\`, \`app-env\`, and \`privileged-app\` components
- Drop the \`&app-deployment\` anchor and port/hostname replacements + the JSON patch (nodeSelector + /output mount override)
- Drop the \`images:\` mapping
- Inline Deployment + Service + HTTPRoute
- Use \`nas-media\` for NFS PV+PVC, \`app-tmp-dirs\` for tmpdirs, \`http-route-refs\` for backendRef rewriting
- Pod security stays inline: \`privileged: true\` on the container (raw disk access for ripping discs) + \`fsGroup: 1000\` at the pod level — that's why \`app-pod-hardening\` is intentionally NOT used here

## No cutover

makemkv already rendered with \`component: app\` and Deployment name \`app-deployment\` (via bases/app). No selector mutation. Render is byte-identical to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)