### PR TITLE
Refactor filebrowser: drop resource-providing components

### DIFF
--- a/apps/filebrowser/deployment.yml
+++ b/apps/filebrowser/deployment.yml
@@ -16,6 +16,9 @@ spec:
       labels: *labels
     spec:
       volumes:
+        - name: nas-media
+          persistentVolumeClaim:
+            claimName: nas-media
         - name: config-map
           configMap:
             name: config
@@ -30,6 +33,8 @@ spec:
               value: America/Denver
           envFrom: []
           volumeMounts:
+            - name: nas-media
+              mountPath: /media
             - name: config-map
               mountPath: /home/filebrowser/data/config.yaml
               subPath: config.yaml
@@ -43,3 +48,55 @@ spec:
           ports:
             - name: http
               containerPort: 80
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: app-volume
+  labels:
+    app.kubernetes.io/component: app
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: longhorn-replicated
+  resources:
+    requests:
+      storage: 1G
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app-service
+  labels: &labels
+    app.kubernetes.io/component: app
+spec:
+  selector: *labels
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: internal-route
+  annotations:
+    internal-dns.alpha.kubernetes.io/target: internal.beaver-cloud.xyz
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: internal-beaver-cloud
+      namespace: envoy-gateway-system
+  hostnames:
+    - filebrowser.beaver-cloud.xyz
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ''
+          kind: Service
+          name: app-service
+          port: 80
+          weight: 1

--- a/apps/filebrowser/kustomization.yml
+++ b/apps/filebrowser/kustomization.yml
@@ -9,12 +9,10 @@ resources:
   - ./deployment.yml
 
 components:
-  - ../../components/app-nas-media
-  - ../../components/internal-http-route
-  - ../../components/app-http-service
+  - ../../components/http-route-refs
+  - ../../components/nas-media
   - ../../components/app-pod-hardening
   - ../../components/app-tmp-dirs
-  - ../../components/app-volume
 
 configMapGenerator:
   - name: config
@@ -26,14 +24,6 @@ configMapGenerator:
         gatus.io/enabled: 'true'
     files:
       - filebrowser.yml=gatus.yml
-
-replacements:
-  - sourceValue: filebrowser.beaver-cloud.xyz
-    targets:
-      - select:
-          kind: HTTPRoute
-        fieldPaths:
-          - spec.hostnames.0
 
 labels:
   - includeSelectors: true


### PR DESCRIPTION
Filebrowser was already on the cleaner shape — this just brings it the rest of the way:

- Drop \`app-nas-media\`, \`internal-http-route\`, \`app-http-service\`, \`app-volume\` (all the resource-providing components)
- Drop the hostname replacement
- Inline Service, app-volume PVC, HTTPRoute, and the nas-media volume + mount in \`deployment.yml\`
- Keep \`nas-media\` for the NFS PV+PVC, \`app-pod-hardening\`, \`app-tmp-dirs\`
- Add \`http-route-refs\`

Render is byte-identical to main. No cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)